### PR TITLE
:pencil2: Installation script, installation directory error fix.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,10 +1,18 @@
 #!/usr/bin/env bash
 
+# To build first
 cargo build
 
+# Checking environment variables
 if [[ ! -d "$SDKMAN_DIR" ]]; then
   export SDKMAN_DIR="$HOME/.sdkman"
   echo "SDKMAN_DIR environment variable not defined, set to $SDKMAN_DIR"
 fi
 
-find target/debug -maxdepth 1 -executable -type f -exec cp -v {} "$SDKMAN_DIR/libexec" \;
+# Check the directory
+if [[ ! -d "$SDKMAN_DIR/libexec" ]]; then
+  mkdir -p "$SDKMAN_DIR/libexec"
+  echo "Libexec directory does not exist, created to $SDKMAN_DIR/libexec"
+fi
+
+find target/debug -maxdepth 1 ! -name ".cargo-lock" ! -name "*.d" -executable -type f -exec cp -v {} "$SDKMAN_DIR/libexec/" \;


### PR DESCRIPTION
# Past
```shell
╭─root@XS in /mnt/d/.repos/.github/xs-fork/sdkman-cli-native on master ✔ (origin/master)
╰$ find target/debug -maxdepth 1 -executable -type f -exec cp -v {} "$SDKMAN_DIR/libexec" \;
'target/debug/.cargo-lock' -> '/root/.sdkman/libexec'
'target/debug/help' -> '/root/.sdkman/libexec'
'target/debug/help.d' -> '/root/.sdkman/libexec'
'target/debug/version' -> '/root/.sdkman/libexec'
'target/debug/version.d' -> '/root/.sdkman/libexec'
```
# Now
```shell
╭─root@XS in /mnt/d/.repos/.github/xs-fork/sdkman-cli-native on master ✔ (origin/master)
╰$ ./install.sh
    Finished dev [unoptimized + debuginfo] target(s) in 2.31s
Libexec directory does not exist, created to /root/.sdkman/libexec
'target/debug/help' -> '/root/.sdkman/libexec/help'
'target/debug/version' -> '/root/.sdkman/libexec/version'
```

# Because
```shell
# In ~/.sdkman/src/sdkman-main.sh file
# Native commands found under libexec
local native_command="${SDKMAN_DIR}/libexec/${COMMAND}"
# libexec is directory 
```