### PR TITLE
refactor: Update release configuration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,6 +137,11 @@ jobs:
           JRELEASER_PROJECT_VERSION: ${{ needs.prerelease.outputs.VERSION }}
           JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           JRELEASER_SKIP_TAG: true
+          JRELEASER_TWITTER_CONSUMER_KEY: ${{ secrets.TWITTER_CONSUMER_API_KEY }}
+          JRELEASER_TWITTER_CONSUMER_SECRET: ${{ secrets.TWITTER_CONSUMER_API_SECRET }}
+          JRELEASER_TWITTER_ACCESS_TOKEN: ${{ secrets.TWITTER_ACCESS_TOKEN }}
+          JRELEASER_TWITTER_ACCESS_TOKEN_SECRET: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
+          JRELEASER_MASTODON_ACCESS_TOKEN: ${{ secrets.MASTODON_ACCESS_TOKEN}}
 
       - name: JReleaser output
         if: always()

--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -5,14 +5,14 @@ project:
   name: sdkman
   description: SDKMAN! native extensions
   longDescription: Supplementary native extension binaries to replace SDKMAN! bash functions.
-  website: 'https://github.com/sdkman/sdkman-native-cli'
   authors:
     - Marco Vermeulen
     - Oliver Weiler
-  license: Apache 2.0
-  licenseUrl: 'https://spdx.org/licenses/Apache-2.0.html'
-  extraProperties:
-    inceptionYear: 2021
+  license: Apache-2.0
+  links:
+    homepage: 'https://github.com/sdkman/sdkman-native-cli'
+    license: 'https://spdx.org/licenses/Apache-2.0.html'
+  inceptionYear: 2021
 platform:
   replacements:
     osx-x86_64: x86_64-apple-darwin
@@ -25,7 +25,6 @@ release:
     overwrite: true
     changelog:
       formatted: ALWAYS
-      format: '- {{commitShortHash}} {{commitTitle}}'
       preset: conventional-commits
       contributors:
         format: '- {{contributorName}}{{#contributorUsernameAsLink}} ({{.}}){{/contributorUsernameAsLink}}'
@@ -65,3 +64,11 @@ distributions:
         platform: linux-x86_64
       - path: '{{artifactsDir}}/{{distributionName}}-{{projectVersion}}-aarch64-unknown-linux-gnu.zip'
         platform: linux-aarch_64
+announce:
+  twitter:
+    active: NEVER
+    status: 'Released version {{tagName}} of SDKMAN! {{releaseNotesUrl}}'
+  mastodon:
+    active: NEVER
+    host: https://fosstodon.org
+    status: 'Released version {{tagName}} of SDKMAN! {{releaseNotesUrl}}'


### PR DESCRIPTION
Update JReleaser configuration to 1.5.1
Configure Twitter & Mastodon announcers

**WARNING:** Announcers are disabled by default. Please review the text for each service and change their `active` property to `ALWAYS` once satisfied.