### PR TITLE
install.sh create .sdkman/libexec if missing.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,12 +2,25 @@
 
 project_root="$(dirname -- "$0")"
 sdkman_dir="${SDKMAN_DIR:-$HOME/.sdkman}"
+sdkman_libexec_dir="${sdkman_dir}/libexec"
 
 # TODO: use --artifact-dir when it stable
 # https://github.com/rust-lang/cargo/issues/6790
 cargo build --manifest-path "$project_root/Cargo.toml"
+
+# Create SDKMAN libexec directory if it does not exist.
+if [ ! -d "${sdkman_libexec_dir}" ]; then
+    mkdir -p  "${sdkman_libexec_dir}" || exit 1
+fi
+
+# Copy files.
 for file in target/debug/*; do
     if [ -f "$file" ] && [ -x "$file" ]; then
-        cp "$file" "$sdkman_dir/libexec/"
+        cp "$file" "${sdkman_libexec_dir}/"
     fi
 done
+
+# Report completion.
+printf -- "All files installed in: %s\n"  "${sdkman_libexec_dir}"
+
+# --


### PR DESCRIPTION
* The script was not creating the missing directory.
* I also added printing the name of the directory where files were copied. New users (like me) may want to know where files went.