### PR TITLE
feat: add RISC-V 64-bit platform support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,7 @@ jobs:
           - {target: x86_64-unknown-linux-gnu, os: ubuntu-latest, container: 'ubuntu:20.04', jreleaser_platform: linux-x86_64}
           - {target: i686-unknown-linux-gnu, os: ubuntu-latest, container: 'ubuntu:20.04', jreleaser_platform: linux-x86_32}
           - {target: aarch64-unknown-linux-gnu, os: ubuntu-latest, container: 'ubuntu:20.04', jreleaser_platform: linux-aarch_64}
+          - {target: riscv64gc-unknown-linux-gnu, os: ubuntu-latest, container: 'ubuntu:20.04', jreleaser_platform: linux-riscv_64}
     runs-on: ${{ matrix.job.os }}
     container:
       image: ${{ matrix.job.container }}

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Nothing needs to be done if you are using one of the following supported archite
 * aarch64-unknown-linux-gnu
 * x86_64-unknown-linux-gnu
 * i686-unknown-linux-gnu
+* riscv64gc-unknown-linux-gnu
 * aarch64-apple-darwin
 * x86_64-apple-darwin
 * x86_64-pc-windows-msvc

--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -17,6 +17,7 @@ platform:
     linux-x86_64: x86_64-unknown-linux-gnu
     linux-x86_32: i686-unknown-linux-gnu
     linux-aarch_64: aarch64-unknown-linux-gnu
+    linux-riscv_64: riscv64gc-unknown-linux-gnu
     windows-x86_64: x86_64-pc-windows-msvc
 release:
   github:
@@ -66,6 +67,8 @@ distributions:
         platform: linux-x86_32
       - path: 'artifacts-aarch64-unknown-linux-gnu/{{distributionName}}-{{projectVersion}}-aarch64-unknown-linux-gnu.zip'
         platform: linux-aarch_64
+      - path: 'artifacts-riscv64gc-unknown-linux-gnu/{{distributionName}}-{{projectVersion}}-riscv64gc-unknown-linux-gnu.zip'
+        platform: linux-riscv_64
 announce:
   twitter:
     active: ALWAYS


### PR DESCRIPTION
## Summary

- Add `riscv64gc-unknown-linux-gnu` to the CI release build matrix, using the same `ubuntu:20.04` container + `taiki-e/setup-cross-toolchain-action@v1` cross-compilation approach as the existing aarch64 and i686 targets
- Add JReleaser platform replacement (`linux-riscv_64`) and distribution artifact mapping
- Update README with the new supported architecture

## Details

No Rust code changes needed — `std::env::consts::ARCH` already returns `"riscv64"` natively. The gap was only in the build/release pipeline.

The `gcc-riscv64-linux-gnu` cross-compiler [is available in Ubuntu 20.04 (Focal)](https://launchpad.net/ubuntu/focal/+package/gcc-riscv64-linux-gnu), so the existing container image works without changes.

Closes #367

## Test plan

- [ ] Verify YAML indentation and naming consistency (`linux-riscv_64` follows `linux-x86_64`, `linux-x86_32`, `linux-aarch_64` convention)
- [ ] Confirm `riscv64gc-unknown-linux-gnu` is a valid Rust target triple
- [ ] CI release workflow builds successfully for the new target