### PR TITLE
fix(ci): use ubuntu:22.04 for RISC-V cross-compilation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
           - {target: x86_64-unknown-linux-gnu, os: ubuntu-latest, container: 'ubuntu:20.04', jreleaser_platform: linux-x86_64}
           - {target: i686-unknown-linux-gnu, os: ubuntu-latest, container: 'ubuntu:20.04', jreleaser_platform: linux-x86_32}
           - {target: aarch64-unknown-linux-gnu, os: ubuntu-latest, container: 'ubuntu:20.04', jreleaser_platform: linux-aarch_64}
-          - {target: riscv64gc-unknown-linux-gnu, os: ubuntu-latest, container: 'ubuntu:20.04', jreleaser_platform: linux-riscv_64}
+          - {target: riscv64gc-unknown-linux-gnu, os: ubuntu-latest, container: 'ubuntu:22.04', jreleaser_platform: linux-riscv_64}
     runs-on: ${{ matrix.job.os }}
     container:
       image: ${{ matrix.job.container }}


### PR DESCRIPTION
## Summary

- Use `ubuntu:22.04` container instead of `ubuntu:20.04` for the `riscv64gc-unknown-linux-gnu` build target in the release workflow
- Fixes linker error `unsupported ISA subset 'z'` caused by old binutils in ubuntu:20.04 not recognizing newer RISC-V ISA extensions (`zaamo`, `zalrsc`, `zca`, `zcd`, `zmmul`) emitted by the Rust stable compiler
- Other Linux targets (x86_64, i686, aarch64) remain on `ubuntu:20.04` for maximum glibc compatibility

## Context

The release workflow [run #21783422096](https://github.com/sdkman/sdkman-cli-native/actions/runs/21783422096) failed on the `Build riscv64gc-unknown-linux-gnu` job. 

Ubuntu 22.04 ships `gcc-12-riscv64-linux-gnu` with binutils >= 2.38 which supports these extensions.

## Test plan

- [ ] PR checks (fmt, check, test) pass on ubuntu/windows/macos
- [ ] Actual cross-compilation verified by triggering the Release workflow (manual dispatch)