### PR TITLE
fix(ci): work around JReleaser lacking riscv64 platform support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,14 +93,17 @@ jobs:
         with:
           target: ${{ matrix.job.target }}
 
-      - name: Install SDKMAN and JReleaser (Linux containers)
+      - name: Install SDKMAN, Java, and JReleaser (Linux containers)
         if: matrix.job.container
         shell: bash
         run: |
           curl -s "https://get.sdkman.io" | bash
           source ~/.sdkman/bin/sdkman-init.sh
           sdk install java 17.0.2-tem
-          sdk install jreleaser
+          # Use JReleaser early-access for linux-riscv_64 platform support
+          curl -sL https://github.com/jreleaser/jreleaser/releases/download/early-access/jreleaser-early-access.zip -o /tmp/jreleaser.zip
+          unzip -q /tmp/jreleaser.zip -d /opt
+          ln -s /opt/jreleaser-*/bin/jreleaser /usr/local/bin/jreleaser
 
       - name: Build
         run: cargo build --locked --release --target=${{ matrix.job.target }}
@@ -120,7 +123,7 @@ jobs:
         if: '!matrix.job.container'
         uses: jreleaser/release-action@v2
         with:
-          version: latest
+          version: early-access
           arguments: assemble
         env:
           JRELEASER_PROJECT_VERSION: ${{ needs.prerelease.outputs.VERSION }}
@@ -159,7 +162,7 @@ jobs:
       - name: Release
         uses: jreleaser/release-action@v2
         with:
-          version: latest
+          version: early-access
           arguments: release -PskipArchiveResolver
         env:
           JRELEASER_PROJECT_VERSION: ${{ needs.prerelease.outputs.VERSION }}


### PR DESCRIPTION
## Summary

- JReleaser 1.22.0 does not recognize `linux-riscv_64` as a valid platform identifier, causing the RISC-V assemble step to fail
- The fix was merged upstream into JReleaser ([PR #2062](https://github.com/jreleaser/jreleaser/pull/2062)) and is available in the `early-access` pre-release (1.23.0-SNAPSHOT)
- Switch all JReleaser usage to `early-access` which includes `riscv_64` in `PlatformUtils.OS_ARCHS`

## Changes

- Install JReleaser early-access from GitHub releases instead of SDKMAN stable in Linux containers
- Use `version: early-access` for `jreleaser/release-action@v2` (non-Linux assemble + release steps)
- No special workaround needed — all platforms use the same JReleaser version

## Follow-up

Revert to `version: latest` (or `sdk install jreleaser`) once JReleaser 1.23.0 is released as stable.

## Test plan

- [ ] Verify all platform builds succeed, including `riscv64gc-unknown-linux-gnu`
- [ ] Verify the release job picks up all artifacts correctly

Fixes the failure at https://github.com/sdkman/sdkman-cli-native/actions/runs/21784738134