### PR TITLE
feat: lower GLIBC compatibility floor to 2.17 using cargo-zigbuild

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,13 +61,10 @@ jobs:
           - {target: aarch64-apple-darwin, os: macos-latest, jreleaser_platform: osx-aarch_64}
           - {target: x86_64-apple-darwin, os: macos-latest, jreleaser_platform: osx-x86_64}
           - {target: x86_64-pc-windows-msvc, os: windows-latest, jreleaser_platform: windows-x86_64}
-          - {target: x86_64-unknown-linux-gnu, os: ubuntu-latest, container: 'ubuntu:20.04', jreleaser_platform: linux-x86_64}
-          - {target: i686-unknown-linux-gnu, os: ubuntu-latest, container: 'ubuntu:20.04', jreleaser_platform: linux-x86_32}
-          - {target: aarch64-unknown-linux-gnu, os: ubuntu-latest, container: 'ubuntu:20.04', jreleaser_platform: linux-aarch_64}
+          - {target: x86_64-unknown-linux-gnu, os: ubuntu-latest, linux: true, jreleaser_platform: linux-x86_64}
+          - {target: i686-unknown-linux-gnu, os: ubuntu-latest, linux: true, jreleaser_platform: linux-x86_32}
+          - {target: aarch64-unknown-linux-gnu, os: ubuntu-latest, linux: true, jreleaser_platform: linux-aarch_64}
     runs-on: ${{ matrix.job.os }}
-    container:
-      image: ${{ matrix.job.container }}
-      options: --privileged
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -75,48 +72,30 @@ jobs:
           fetch-depth: 0
           ref: master
 
-      - name: Install dependencies (Linux containers)
-        if: matrix.job.container
-        run: |
-          apt-get update
-          apt-get install -y curl build-essential zip unzip
-
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.job.target }}
 
       - name: Setup cross-compilation toolchain
-        if: matrix.job.container
+        if: matrix.job.linux
         uses: taiki-e/setup-cross-toolchain-action@v1
         with:
           target: ${{ matrix.job.target }}
 
-      - name: Install SDKMAN and JReleaser (Linux containers)
-        if: matrix.job.container
-        shell: bash
-        run: |
-          curl -s "https://get.sdkman.io" | bash
-          source ~/.sdkman/bin/sdkman-init.sh
-          sdk install java 17.0.2-tem
-          sdk install jreleaser
+      - name: Install cargo-zigbuild
+        if: matrix.job.linux
+        run: cargo install cargo-zigbuild
 
-      - name: Build
+      - name: Build (Linux, GLIBC 2.17 floor)
+        if: matrix.job.linux
+        run: cargo zigbuild --locked --release --target=${{ matrix.job.target }}.2.17
+
+      - name: Build (non-Linux)
+        if: '!matrix.job.linux'
         run: cargo build --locked --release --target=${{ matrix.job.target }}
 
-      - name: Assemble (Linux containers)
-        if: matrix.job.container
-        shell: bash
-        run: |
-          source ~/.sdkman/bin/sdkman-init.sh
-          jreleaser assemble
-        env:
-          JRELEASER_PROJECT_VERSION: ${{ needs.prerelease.outputs.VERSION }}
-          JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          JRELEASER_PLATFORM_OVERRIDE: ${{ matrix.job.jreleaser_platform }}
-
-      - name: Assemble (Non-Linux)
-        if: '!matrix.job.container'
+      - name: Assemble
         uses: jreleaser/release-action@v2
         with:
           version: latest


### PR DESCRIPTION
- Replace Ubuntu 20.04 container with ubuntu-latest runner
- Use cargo-zigbuild for explicit GLIBC 2.17 target floor
- Covers CentOS 7, Amazon Linux 2, Ubuntu 18.04+
- Eliminates distro/runner lock-in
- Ref: issue #152