### PR TITLE
fix: pass pr_ci_workflow input to digest caller

### DIFF
--- a/.github/workflows/dependabot-digest.yml
+++ b/.github/workflows/dependabot-digest.yml
@@ -9,5 +9,8 @@ jobs:
   digest:
     permissions:
       pull-requests: read
+      actions: read
     uses: sdkman/.github/.github/workflows/reusable-dependabot-digest.yml@main
+    with:
+      pr_ci_workflow: "Pull Requests"
     secrets: inherit


### PR DESCRIPTION
## What
Pass the now-required `pr_ci_workflow` input (and grant `actions: read`) to the Dependabot Digest caller, matching the reusable's `workflow_call` contract.

## Why
`reusable-dependabot-digest.yml@main` made `pr_ci_workflow` a required input. Callers that omit it fail at startup (`startup_failure`). This brings sdkman-cli-native in line with sdkman-state and sdkman-broker-2.

## Verification
`actionlint` clean.